### PR TITLE
Ruby 2.4 compat

### DIFF
--- a/lib/micro-optparse.rb
+++ b/lib/micro-optparse.rb
@@ -1,1 +1,1 @@
-require 'micro-optparse/parser'
+require_relative './micro-optparse/parser'

--- a/lib/micro-optparse/parser.rb
+++ b/lib/micro-optparse/parser.rb
@@ -46,7 +46,7 @@ class Parser
         @used_short << short = o[:settings][:no_short] ? nil : o[:settings][:short] || short_from(o[:name])
         @result[o[:name]] = o[:settings][:default] || false unless o[:settings][:optional] # set default
         name = o[:name].to_s.gsub("_", "-")
-        klass = o[:settings][:default].class == Fixnum ? Integer : o[:settings][:default].class
+        klass = o[:settings][:default].is_a?(Integer) ? Integer : o[:settings][:default].class
 
         args = [o[:description]]
         args << "-" + short if short

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1,4 +1,4 @@
-require "micro-optparse"
+require_relative "../lib/micro-optparse"
 
 RSpec.configure do |config|
   config.expect_with :rspec do |c|

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1,5 +1,11 @@
 require "micro-optparse"
 
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
+end
+
 describe Parser do
   before(:all) do
     @evolutionary_algorithm_parser = Parser.new do |p|

--- a/spec/programs/eating.rb
+++ b/spec/programs/eating.rb
@@ -1,5 +1,5 @@
 require "rubygems"
-require "micro-optparse"
+require_relative "../../lib/micro-optparse"
 
 options = Parser.new do |p|
   p.version = "EatingScript 1.0 (c) Florian Pilz 2011"

--- a/spec/programs/empty.rb
+++ b/spec/programs/empty.rb
@@ -1,5 +1,5 @@
 require "rubygems"
-require "micro-optparse"
+require_relative "../../lib/micro-optparse"
 
 options = Parser.new do |p|
 end.process!

--- a/spec/programs/noshort.rb
+++ b/spec/programs/noshort.rb
@@ -1,5 +1,5 @@
 require "rubygems"
-require "micro-optparse"
+require_relative "../../lib/micro-optparse"
 
 options = Parser.new do |p|
   p.option :foo, "Option 1", :default => "String", :no_short => true

--- a/spec/programs/short.rb
+++ b/spec/programs/short.rb
@@ -1,5 +1,5 @@
 require "rubygems"
-require "micro-optparse"
+require_relative "../../lib/micro-optparse"
 
 options = Parser.new do |p|
   p.option :abc, "Option 1", :default => "String"

--- a/spec/programs/version.rb
+++ b/spec/programs/version.rb
@@ -1,5 +1,5 @@
 require "rubygems"
-require "micro-optparse"
+require_relative "../../lib/micro-optparse"
 
 options = Parser.new do |p|
   p.version = "VersionScript 0.0 (c) Florian Pilz 2011"


### PR DESCRIPTION
This removes reference to `Fixnum` so that Ruby 2.4 will not issue warnings.

Along with that, this configures newer rspec to still allow the `should` syntax and updates the `require` statements to use `require_relative` so the tests can execute against the local copy of **micro-optparse** even if an older version is installed as a gem.